### PR TITLE
chore: 资源检查更新功能优化和修改。

### DIFF
--- a/Assets/AllSkyFree/Epic_BlueSunset/Epic_BlueSunset.mat
+++ b/Assets/AllSkyFree/Epic_BlueSunset/Epic_BlueSunset.mat
@@ -95,7 +95,7 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
-    - _Rotation: 22758.484
+    - _Rotation: 26346.83
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/Assets/Resources/Prefabs/UI/Panel/DownLoadPanel.prefab
+++ b/Assets/Resources/Prefabs/UI/Panel/DownLoadPanel.prefab
@@ -97,6 +97,8 @@ MonoBehaviour:
   m_ProgressPercent: {fileID: 742760855910101999}
   m_Hint: {fileID: 4751674306315047365}
   m_Finish: {fileID: 4751674307182522356}
+  m_Finished: 1
+  m_NeedDL: []
 --- !u!1 &742760855682827729
 GameObject:
   m_ObjectHideFlags: 0
@@ -289,7 +291,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -126.2, y: 66.8}
+  m_AnchoredPosition: {x: 345, y: 66.8}
   m_SizeDelta: {x: 0, y: 27.4665}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &742760855910101998
@@ -320,7 +322,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 0%
+  m_text: 0.00%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 061a00547a00c3e459c1d298043041ce, type: 2}
   m_sharedMaterial: {fileID: -86810614298320187, guid: 061a00547a00c3e459c1d298043041ce, type: 2}
@@ -716,7 +718,7 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 1
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -998,7 +1000,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\u7B49\u5F85\u8D44\u6E90\u66F4\u65B0\uFF1A"
+  m_text: "\u7B49\u5F85\u8D44\u6E90\u66F4\u65B0..."
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 061a00547a00c3e459c1d298043041ce, type: 2}
   m_sharedMaterial: {fileID: -86810614298320187, guid: 061a00547a00c3e459c1d298043041ce, type: 2}
@@ -1184,7 +1186,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.3773585, g: 0.3773585, b: 0.3773585, a: 1}
+    m_DisabledColor: {r: 0.5377358, g: 0.5377358, b: 0.5377358, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:

--- a/Assets/Scripts/Frame/Asset/AssetConsole.cs
+++ b/Assets/Scripts/Frame/Asset/AssetConsole.cs
@@ -90,7 +90,6 @@ public class AssetConsole : Singleton<AssetConsole>
         }
         result.isLoad = true;
     }
-
 }
 
 public class AsyncResult

--- a/Assets/Scripts/Frame/GlobalData.cs
+++ b/Assets/Scripts/Frame/GlobalData.cs
@@ -78,6 +78,12 @@ namespace sugar
         // 场景模型实例
         public static GameObject SceneModel;
 
+        // 单个文件是否更新检查完毕(PDF, 视频，图片)
+        public static bool Checked = false;
+
+        // 单个文件是否下载完毕存储在内存中(PDF, 视频，图片)
+        public static bool Downloaded = false;
+
         // 是否为最新的资源(PDF, 视频，图片)
         public static bool IsLatestRes = false;
     }

--- a/Assets/Scripts/Frame/Network/NetworkClientTCP.cs
+++ b/Assets/Scripts/Frame/Network/NetworkClientTCP.cs
@@ -72,6 +72,7 @@ public static class NetworkClientTCP
         {
             string mess = Encoding.Unicode.GetString(buffer, 0, length);
             Array.Clear(buffer, 0, buffer.Length);
+            // Debug.Log("+++++" + mess); // log message of front package
 
             if (!mp.get_length)
             {
@@ -83,6 +84,7 @@ public static class NetworkClientTCP
 
                 FrontPackage fp = new FrontPackage();
                 fp.eventType = data["event_type"].ToString();
+                percent = 0.0f; // 在准备队列填装之前 清空上一次消息留下的百分比
                 m_FrontQueue.Enqueue(fp);
             }
             else
@@ -93,7 +95,7 @@ public static class NetworkClientTCP
                 }
 
                 percent = (float)mp.ret.Count() * 1.0f / (float)mp.length * 1.0f * 100.0f;
-                Debug.Log("----------" + mp.ip + " | " + percent + "%");  // Add message package for queue.
+                // Debug.Log("----------" + percent + " || " + mess);  // Add message package for queue.
 
                 if (percent >= 100.0f)
                 {
@@ -102,7 +104,7 @@ public static class NetworkClientTCP
                     mp.Clear();
                 }
             }
-            Debug.Log("+++++" + mess); // log message of front package
+
             m_Socket.BeginReceive(buffer, 0, buf_length, 0, ReviceAsyncCallback, mp);
         }
         catch

--- a/Assets/Scripts/Frame/Network/NetworkManager.cs
+++ b/Assets/Scripts/Frame/Network/NetworkManager.cs
@@ -21,7 +21,7 @@ public class NetworkManager : MonoBehaviour
         NetworkClientTCP.Connect("192.168.3.34", 5800);
     }
 
-    public void FixedUpdate()
+    public void Update()
     {
         if (NetworkClientTCP.m_FrontQueue.Count > 0)
         {

--- a/Assets/Scripts/Frame/Storage/StorageExpand.cs
+++ b/Assets/Scripts/Frame/Storage/StorageExpand.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using LitJson;
 using System.IO;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public static class StorageExpand
@@ -12,19 +13,26 @@ public static class StorageExpand
     {
         get
         {
-            if (m_storage == null)
-            {
-                m_storage = Resources.Load("Storage/Clump") as StorageObject;
-            }
-
-            if (File.Exists(Application.streamingAssetsPath + "\\CliStorage.json") && !m_Init)
-            {
-                string s_json = File.ReadAllText(Application.streamingAssetsPath + "\\CliStorage.json");
-                m_storage = JsonMapper.ToObject<StorageObject>(s_json);
-                m_Init = true;
-            }
+            getStorage();
             return m_storage;
         }
+    }
+
+    public async static void getStorage()
+    {
+        await UniTask.SwitchToMainThread();
+        if (m_storage == null)
+        {
+            m_storage = Resources.Load("Storage/Clump") as StorageObject;
+        }
+
+        if (File.Exists(Application.persistentDataPath + "\\CliStorage.json") && !m_Init)
+        {
+            string s_json = File.ReadAllText(Application.persistentDataPath + "\\CliStorage.json");
+            JsonUtility.FromJsonOverwrite(s_json, m_storage);
+            m_Init = true;
+        }
+        await UniTask.WaitUntil(() => { return m_storage != null; } );
     }
 
     /// <summary>
@@ -80,6 +88,6 @@ public static class StorageExpand
     {
         await UniTask.SwitchToMainThread();
         string s_json = JsonMapper.ToJson(Storage);
-        File.WriteAllText(Application.streamingAssetsPath + "/CliStorage.json", s_json);
+        File.WriteAllText(Application.persistentDataPath + "/CliStorage.json", s_json);
     }
 }

--- a/Assets/Scripts/Frame/Tools/Tools.cs
+++ b/Assets/Scripts/Frame/Tools/Tools.cs
@@ -342,16 +342,19 @@ public static class Tools
         FileStream fs = new FileStream(save_path, FileMode.CreateNew);
         lock (fs)
         {
-            BinaryWriter bw = new BinaryWriter(fs);
-            lock (bw)
-            {
-                bw.Write(buffer, 0, buffer.Length);
-                bw.Close();
-            }
+            fs.Write(buffer, 0, buffer.Length);
+            //BinaryWriter bw = new BinaryWriter(fs);
+            //lock (bw)
+            //{
+            //    bw.Write(buffer, 0, buffer.Length);
+            //    bw.Close();
+            //}
             fs.Close();
         }
 
         await UniTask.WaitUntil(() => File.Exists(save_path) == true);
+
+        DownLoadPanel._instance.SetWritePercent(100.0f);
         GlobalData.IsLatestRes = true;
     }
 
@@ -362,5 +365,37 @@ public static class Tools
     public static string SpawnRandomCode()
     {
         return $"{Random.Range(1000, 9999)}-{Random.Range(1000, 9999)}-{Random.Range(1000, 9999)}-{Random.Range(1000, 9999)}";
+    }
+
+    /// <summary>
+    /// 获取Action中每个文件的相对路径
+    /// </summary>
+    /// <param name="path"> 文件绝对路径 </param>
+    /// <param name="name"> 模块名 </param>
+    /// <returns></returns>
+    public static string GetFileRelativePath(string path, string name)
+    {
+        string[] split = path.Split('/');
+        string filename = split[split.Length - 1];
+        string suffix = Tools.GetModulePath(name);
+        string relaPath = $"{GlobalData.currModuleCode}{suffix}\\{filename}";
+
+        return relaPath;
+    }
+
+    /// <summary>
+    /// 将内存中的文件列表写入硬盘
+    /// </summary>
+    /// <returns></returns>
+    public static async UniTask WtMem2DiskOfFileList(List<FilePackage> fpList)
+    {
+        foreach (var fp in fpList)
+        {
+            string savePath = Application.streamingAssetsPath + "\\Data\\" + fp.relativePath;
+            Bytes2File(fp.fileData, savePath);
+
+            await UniTask.WaitUntil(() => GlobalData.IsLatestRes == true);
+            GlobalData.IsLatestRes = false;
+        }
     }
 }

--- a/Assets/Scripts/RunTime/Action/PDF/PDFAction.cs
+++ b/Assets/Scripts/RunTime/Action/PDF/PDFAction.cs
@@ -20,8 +20,6 @@ public class PDFAction : BaseAction
 
     public PDFAction()
     {
-        m_Panel = UIConsole.Instance.FindAssetPanel<PDFPanel>();
-
         m_Token = new CancellationTokenSource();
         m_panelToken = new CancellationTokenSource();
     }
@@ -30,15 +28,14 @@ public class PDFAction : BaseAction
     {
         if (!m_initList.ContainsKey(name))
         {
-            await NetworkManager._Instance.DownLoadConfigAsync(name, (paths) =>
+            await NetworkManager._Instance.DownLoadConfigAsync(name, async (paths) =>
             {
                 if (paths.Count == 0)
                     UITools.ShowMessage("当前模块没有PDF资源");
 
-                // 资源更新请求
-                // NetworkClientTCP.SendAsync();
-                // await UniTask.WaitUntil(() => GlobalData.IsLatestRes == true);
+                await NetworkTCPExpand.RsCkAndDLReq(paths, name);
 
+                m_Panel = UIConsole.Instance.FindAssetPanel<PDFPanel>();
                 m_Panel.Init(paths, name);
                 m_initList.Add(name, paths);
                 m_init = true;

--- a/Assets/Scripts/RunTime/Action/Picture/PictureAction.cs
+++ b/Assets/Scripts/RunTime/Action/Picture/PictureAction.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using sugar;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,8 +16,6 @@ public class PictureAction : BaseAction
 
     public PictureAction()
     {
-        m_Panel = UIConsole.Instance.FindAssetPanel<PicturePanel>();
-
         m_Token = new CancellationTokenSource();
         m_panelToken = new CancellationTokenSource();
     }
@@ -26,6 +25,8 @@ public class PictureAction : BaseAction
         if (!m_Init)
         {
             List<Sprite> sprites = await LoadPictureAsync(name);
+
+            m_Panel = UIConsole.Instance.FindAssetPanel<PicturePanel>();
             m_Panel.Init(sprites);
             m_Init = true;
         }
@@ -49,16 +50,15 @@ public class PictureAction : BaseAction
         var paths = await NetworkManager._Instance.DownLoadAasetAsync(name);
 
         List<Sprite> sprites = new List<Sprite>();
-        //foreach (var path in paths)
-        //{
-        //    Debug.Log("picture action: " + path);
-        //}
 
         if (paths.Count == 0)
             UITools.ShowMessage("当前模块没有图片资源");
 
         AsyncResult result = await AssetConsole.Instance.LoadTexObject(paths.ToArray());
         await UniTask.WaitUntil(() => result.isLoad == true);
+
+        await NetworkTCPExpand.RsCkAndDLReq(paths, name);
+
         foreach (var spo in result.m_Assets)
         {
             sprites.Add(Tools.SpriteConvert((Texture2D)spo.Value));

--- a/Assets/Scripts/RunTime/Action/Video/VideoAction.cs
+++ b/Assets/Scripts/RunTime/Action/Video/VideoAction.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using sugar;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -16,8 +17,6 @@ public class VideoAction : BaseAction
 
     public VideoAction()
     {
-        m_Panel = UIConsole.Instance.FindAssetPanel<VideoPanel>();
-
         m_Token = new CancellationTokenSource();
         m_panelToken = new CancellationTokenSource();
     }
@@ -32,12 +31,17 @@ public class VideoAction : BaseAction
             {
                 UITools.ShowMessage("当前模块没有Video资源");
             }
+
+            await NetworkTCPExpand.RsCkAndDLReq(paths, name);
+
+            m_Panel = UIConsole.Instance.FindAssetPanel<VideoPanel>();
             m_Panel.Init(paths);
             m_initList.Add(name, paths);
             m_init = true;
         }
         else
         {
+            m_Panel = UIConsole.Instance.FindAssetPanel<VideoPanel>();
             m_Panel.Init(m_initList[name]);
             m_init = true;
         }

--- a/Assets/Scripts/RunTime/Event/BaseEvent.cs
+++ b/Assets/Scripts/RunTime/Event/BaseEvent.cs
@@ -47,7 +47,7 @@ public class BaseEvent
     /// <summary>
     /// [limite] network unity socket tcp server message: 事件开始前处理前置包内容
     /// </summary>
-    public virtual async void OnPrepare(params object[] args) { await UniTask.Yield(); }
+    public virtual void OnPrepare(params object[] args) {  }
 
     /// <summary>
     /// 点击每个模式不同的事件

--- a/Assets/Scripts/RunTime/Event/CheckEvent.cs
+++ b/Assets/Scripts/RunTime/Event/CheckEvent.cs
@@ -16,13 +16,11 @@ public class CheckEvent : BaseEvent
             {
                 info.need_updata = false;
                 StorageExpand.UpdateThisFileInfo(info);
-                NetworkTCPExpand.DownLoadResourcesReq(info.relaPath);
+
+                string path = info.relaPath;
+                DownLoadPanel._instance.m_NeedDL.Add(path);
             }
-            else
-            {
-                //StorageExpand.UpdateThisFileInfo(info);
-                GlobalData.IsLatestRes = true;
-            }
+            GlobalData.Checked = true;
         });
     }
 }

--- a/Assets/Scripts/UI/Panel/Load/LoadingPanel.cs
+++ b/Assets/Scripts/UI/Panel/Load/LoadingPanel.cs
@@ -82,9 +82,7 @@ public class LoadingPanel : BasePanel, IGlobalPanel
 
             if (real_percent > percent) // 顯示Loading窗口，比較平緩的滑動進度條。
             {
-
                 percent += Time.deltaTime;
-
                 percent = Mathf.Clamp01(percent);
             }
             m_ProgressSlider.value = percent;

--- a/Assets/Scripts/UI/Panel/MenuGridPanel/MenuGridPanel.cs
+++ b/Assets/Scripts/UI/Panel/MenuGridPanel/MenuGridPanel.cs
@@ -112,6 +112,6 @@ public class MenuGridPanel : BasePanel
         }
         GlobalData.currItemMode = name;
 
-        await m_currAction.AsyncShow(name);
+        await m_currAction.AsyncShow(name).SuppressCancellationThrow();
     }
 }

--- a/Assets/Scripts/UI/Panel/PDFPanel/PDFPanel.cs
+++ b/Assets/Scripts/UI/Panel/PDFPanel/PDFPanel.cs
@@ -20,32 +20,20 @@ public class PDFPanel : BasePanel
     public GameObject m_PDFItemParent;
     public PDFViewer m_PDFViewer;
 
-    private string moudleName = "";
-
     // PDF文件item实例列表
     private List<GameObject> m_Items = new List<GameObject>();
 
     public void Init(List<string> paths, string name)
     {
-        moudleName = name;
         SetPDFActive(false);
         m_PDFPaths = paths;
         SpawnPDFItem();
     }
 
-    private async void SpawnPDFItem()
+    private void SpawnPDFItem()
     {
         foreach (var path in m_PDFPaths)
         {
-            string[] split = path.Split('/');
-            string filename = split[split.Length - 1];
-            string suffix = Tools.GetModulePath(moudleName);
-            string relaPath = $"{GlobalData.currModuleCode}{suffix}\\{filename}";
-
-            NetworkTCPExpand.CheckResourceReq(relaPath);
-            await UniTask.WaitUntil(() => GlobalData.IsLatestRes == true);
-
-            GlobalData.IsLatestRes = false;
             GameObject itemObj = GameObject.Instantiate(m_PDFItem, m_PDFItemParent.transform);
             itemObj.gameObject.SetActive(true);
             Button itemBtn = itemObj.GetComponentInChildren<Button>();
@@ -61,7 +49,6 @@ public class PDFPanel : BasePanel
     {
         m_PDFViewer.LoadDocumentFromFile(path);
         m_PDFViewer.transform.SetAsLastSibling();
-
         m_PDFViewer.gameObject.SetActive(true);
         //SetPDFActive(true);
     }

--- a/Assets/StreamingAssets/CliStorage.json
+++ b/Assets/StreamingAssets/CliStorage.json
@@ -1,1 +1,0 @@
-{"name":"Clump","hideFlags":0,"rsCheck":[{"relaPath":"10001\\JiaoAn\\\u6559\u6848.pdf","version_code":"3052-5228-7569-8739","need_updata":true}]}

--- a/Assets/StreamingAssets/CliStorage.json.meta
+++ b/Assets/StreamingAssets/CliStorage.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ed5fc59b725179c4bb8e7f4cd70b31e8
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
- 将资源更新与传输功能添加到图片，视频模块中[之前只在PDF中添加了]
- 对于多文件传输（从单个文件检查更新 => 文件下载传输 => 文件写入本地依次循环处理多文件）优化为 (先多文件检查更新 => 再多文件下载 => 最后多文件写入本地一体化)
- 进度条修改(从进度条100%全部代表了文件从服务器的下载进度) 修改为 （前90%为文件的从服务器下载进度，后10%为文件写入本地进度[因为后续测试发现大文件从内存写入硬盘也需要一定的时间，需要显示进度]）